### PR TITLE
Change the Java ArtifactId to opentoken and update the project version to 1.9.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -7,9 +7,6 @@ tag = False
 search = <revision>{current_version}</revision>
 replace = <revision>{new_version}</revision>
 
-[bumpversion:file:lib/java/README.md]
-search = {current_version}
-replace = {new_version}
 
 [bumpversion:file:Dockerfile]
 search = VERSION={current_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,12 +1,11 @@
 [bumpversion]
-current_version = 1.9.4
+current_version = 1.9.5
 commit = False
 tag = False
 
 [bumpversion:file:lib/java/pom.xml]
 search = <revision>{current_version}</revision>
 replace = <revision>{new_version}</revision>
-
 
 [bumpversion:file:Dockerfile]
 search = VERSION={current_version}
@@ -27,4 +26,3 @@ replace = "{new_version}"
 [bumpversion:file:lib/python/src/main/opentoken/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
- 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -7,15 +7,7 @@ tag = False
 search = <revision>{current_version}</revision>
 replace = <revision>{new_version}</revision>
 
-[bumpversion:file:README.md]
-search = {current_version}
-replace = {new_version}
-
 [bumpversion:file:lib/java/README.md]
-search = {current_version}
-replace = {new_version}
-
-[bumpversion:file:lib/python/README.md]
 search = {current_version}
 replace = {new_version}
 
@@ -28,13 +20,14 @@ search = DEFAULT_VERSION = "{current_version}";
 replace = DEFAULT_VERSION = "{new_version}";
 
 [bumpversion:file:lib/python/src/main/opentoken/metadata.py]
-search = DEFAULT_VERSION = "{current_version}";
-replace = DEFAULT_VERSION = "{new_version}";
+search = DEFAULT_VERSION = "{current_version}"
+replace = DEFAULT_VERSION = "{new_version}"
 
 [bumpversion:file:lib/python/setup.py]
-search ="{current_version}";
-replace ="{new_version}";
+search = "{current_version}"
+replace = "{new_version}"
 
 [bumpversion:file:lib/python/src/main/opentoken/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
+ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /app
 
 RUN addgroup --system appuser && adduser --system --no-create-home --ingroup appuser appuser
 
-ARG VERSION=1.9.4
+ARG VERSION=1.9.5
 COPY --from=build /app/target/opentoken-${VERSION}.jar /usr/local/lib/opentoken.jar
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,11 @@ RUN mkdir /app
 RUN addgroup --system appuser && adduser --system --no-create-home --ingroup appuser appuser
 
 ARG VERSION=1.9.4
-COPY --from=build /app/target/open-token-${VERSION}.jar /usr/local/lib/open-token.jar
+COPY --from=build /app/target/opentoken-${VERSION}.jar /usr/local/lib/opentoken.jar
 
 WORKDIR /app
 
 RUN chown -R appuser:appuser /app
 USER appuser
 
-ENTRYPOINT ["java", "-jar", "/usr/local/lib/open-token.jar"]
+ENTRYPOINT ["java", "-jar", "/usr/local/lib/opentoken.jar"]

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Quick parity note: Java and Python implementations produce identical tokens for 
 ```shell
 cd lib/java
 mvn clean install
-java -jar target/open-token-<version>.jar \
+java -jar target/opentoken-<version>.jar \
   -i ../../resources/sample.csv -t csv -o target/output.csv \
   -h "HashingKey" -e "Secret-Encryption-Key-Goes-Here."
 ```

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Quick parity note: Java and Python implementations produce identical tokens for 
 ```shell
 cd lib/java
 mvn clean install
-java -jar target/opentoken-<version>.jar \
+java -jar target/opentoken-*.jar \
   -i ../../resources/sample.csv -t csv -o target/output.csv \
   -h "HashingKey" -e "Secret-Encryption-Key-Goes-Here."
 ```

--- a/docs/dev-guide-development.md
+++ b/docs/dev-guide-development.md
@@ -83,13 +83,13 @@ Or from `lib/java` directly:
 ```shell
 mvn clean install
 ```
-Resulting JAR: `lib/java/target/opentoken-<version>.jar`.
+Resulting JAR: `lib/java/target/opentoken-*.jar`.
 
 Using as a Maven dependency:
 
 ```xml
 <dependency>
-  <groupId>com.truveta.opentoken</groupId>
+  <groupId>com.truveta</groupId>
   <artifactId>opentoken</artifactId>
   <version>${opentoken.version}</version>
 </dependency>
@@ -98,7 +98,7 @@ Using as a Maven dependency:
 CLI usage:
 
 ```shell
-cd lib/java && java -jar target/opentoken-<version>.jar [OPTIONS]
+cd lib/java && java -jar target/opentoken-*.jar [OPTIONS]
 ```
 Arguments:
 
@@ -112,7 +112,7 @@ Arguments:
 Example:
 
 ```shell
-cd lib/java && java -jar target/opentoken-<version>.jar \
+cd lib/java && java -jar target/opentoken-*.jar \
   -i src/test/resources/sample.csv -t csv -o target/output.csv \
   -h "HashingKey" -e "Secret-Encryption-Key-Goes-Here."
 ```
@@ -340,7 +340,7 @@ docker build . -t opentoken
 Minimum required arguments:
 
 ```shell
-java -jar target/opentoken-<version>.jar -i input.csv -t csv -o output.csv -h HashingKey -e Secret-Encryption-Key-Goes-Here.
+java -jar target/opentoken-*.jar -i input.csv -t csv -o output.csv -h HashingKey -e Secret-Encryption-Key-Goes-Here.
 ```
 
 Arguments:

--- a/docs/dev-guide-development.md
+++ b/docs/dev-guide-development.md
@@ -83,14 +83,14 @@ Or from `lib/java` directly:
 ```shell
 mvn clean install
 ```
-Resulting JAR: `lib/java/target/open-token-<version>.jar`.
+Resulting JAR: `lib/java/target/opentoken-<version>.jar`.
 
 Using as a Maven dependency:
 
 ```xml
 <dependency>
   <groupId>com.truveta.opentoken</groupId>
-  <artifactId>open-token</artifactId>
+  <artifactId>opentoken</artifactId>
   <version>${opentoken.version}</version>
 </dependency>
 ```
@@ -98,7 +98,7 @@ Using as a Maven dependency:
 CLI usage:
 
 ```shell
-cd lib/java && java -jar target/open-token-<version>.jar [OPTIONS]
+cd lib/java && java -jar target/opentoken-<version>.jar [OPTIONS]
 ```
 Arguments:
 
@@ -112,7 +112,7 @@ Arguments:
 Example:
 
 ```shell
-cd lib/java && java -jar target/open-token-<version>.jar \
+cd lib/java && java -jar target/opentoken-<version>.jar \
   -i src/test/resources/sample.csv -t csv -o target/output.csv \
   -h "HashingKey" -e "Secret-Encryption-Key-Goes-Here."
 ```
@@ -229,7 +229,7 @@ Contributing notes:
 | Build / Package | `mvn clean install` | `pip install -e .` |
 | Run Tests | `mvn test` | `pytest src/test` |
 | Lint / Style | `mvn checkstyle:check` | (pep8 / flake8 if configured) |
-| Run CLI | `java -jar target/open-token-<ver>.jar ...` | `PYTHONPATH=... python ...main.py ...` |
+| Run CLI | `java -jar target/opentoken-<ver>.jar ...` | `PYTHONPATH=... python ...main.py ...` |
 | Add Token | SPI entry & class | new module in `tokens/definitions` |
 | Add Attribute | SPI entry & class | class + loader import |
 
@@ -332,7 +332,7 @@ Maintain tests to guard consistency between languages.
 ### Docker Image
 
 ```shell
-docker build . -t open-token
+docker build . -t opentoken
 ```
 
 ## Running the Tool (CLI)
@@ -340,7 +340,7 @@ docker build . -t open-token
 Minimum required arguments:
 
 ```shell
-java -jar target/open-token-<version>.jar -i input.csv -t csv -o output.csv -h HashingKey -e Secret-Encryption-Key-Goes-Here.
+java -jar target/opentoken-<version>.jar -i input.csv -t csv -o output.csv -h HashingKey -e Secret-Encryption-Key-Goes-Here.
 ```
 
 Arguments:

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.truveta.opentoken</groupId>
-    <artifactId>open-token</artifactId>
+    <artifactId>opentoken</artifactId>
     <packaging>jar</packaging>
     <version>${revision}</version>
 
-    <name>open-token</name>
+    <name>opentoken</name>
     <url>http://www.truveta.com</url>
 
     <distributionManagement>
@@ -370,7 +370,7 @@
                                 <echo message="Running CSV sanity check..." />
                                 <exec executable="java" dir="${basedir}" failonerror="true" outputproperty="csv.output">
                                     <arg value="-jar" />
-                                    <arg value="${project.build.directory}/open-token-${revision}.jar" />
+                                    <arg value="${project.build.directory}/opentoken-${revision}.jar" />
                                     <arg value="-i" />
                                     <arg value="../../resources/sample.csv" />
                                     <arg value="-t" />
@@ -407,7 +407,7 @@
                                 <echo message="Running Parquet sanity check..." />
                                 <exec executable="java" dir="${basedir}" failonerror="true" outputproperty="parquet.output">
                                     <arg value="-jar" />
-                                    <arg value="${project.build.directory}/open-token-${revision}.jar" />
+                                    <arg value="${project.build.directory}/opentoken-${revision}.jar" />
                                     <arg value="-i" />
                                     <arg value="../../resources/sample.parquet" />
                                     <arg value="-t" />

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.truveta.opentoken</groupId>
+    <groupId>com.truveta</groupId>
     <artifactId>opentoken</artifactId>
     <packaging>jar</packaging>
     <version>${revision}</version>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -21,7 +21,7 @@
     </distributionManagement>
 
     <properties>
-        <revision>1.9.4</revision>
+        <revision>1.9.5</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>

--- a/lib/java/src/main/java/com/truveta/opentoken/Metadata.java
+++ b/lib/java/src/main/java/com/truveta/opentoken/Metadata.java
@@ -25,7 +25,7 @@ public class Metadata {
     public static final String METADATA_FILE_EXTENSION = ".metadata.json";
     public static final String SYSTEM_JAVA_VERSION = System.getProperty("java.version");
 
-    public static final String DEFAULT_VERSION = "1.9.4";
+    public static final String DEFAULT_VERSION = "1.9.5";
 
     // Output format values
     public static final String OUTPUT_FORMAT_JSON = "JSON";

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(this_directory, "requirements.txt"), encoding="utf-8") as
 
 setup(
     name="opentoken",
-    version="1.9.4",
+    version="1.9.5",
     author="Truveta",
     description="OpenToken Python implementation for person matching",
     long_description=long_description,

--- a/lib/python/src/main/opentoken/__init__.py
+++ b/lib/python/src/main/opentoken/__init__.py
@@ -7,5 +7,5 @@ This package provides utilities for tokenizing and processing person attributes
 using various cryptographic transformations.
 """
 
-__version__ = "1.9.4"
+__version__ = "1.9.5"
 __author__ = "Truveta"

--- a/lib/python/src/main/opentoken/metadata.py
+++ b/lib/python/src/main/opentoken/metadata.py
@@ -24,7 +24,7 @@ class Metadata:
     METADATA_FILE_EXTENSION = ".metadata.json"
     SYSTEM_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 
-    DEFAULT_VERSION = "1.9.4"
+    DEFAULT_VERSION = "1.9.5"
 
     # Output format values
     OUTPUT_FORMAT_JSON = "JSON"

--- a/tools/interoperability/java_python_interoperability_test.py
+++ b/tools/interoperability/java_python_interoperability_test.py
@@ -27,7 +27,7 @@ class OpenTokenCLI:
     def __init__(self):
         self.project_root = Path(__file__).parent.parent.parent
         java_jar_dir = self.project_root / "lib/java/target"
-    jar_files = list(java_jar_dir.glob("opentoken-*.jar"))
+        jar_files = list(java_jar_dir.glob("opentoken-*.jar"))
         if not jar_files:
             raise FileNotFoundError(f"No OpenToken JAR found in {java_jar_dir}")
         self.java_jar_path = jar_files[0]

--- a/tools/interoperability/java_python_interoperability_test.py
+++ b/tools/interoperability/java_python_interoperability_test.py
@@ -27,7 +27,7 @@ class OpenTokenCLI:
     def __init__(self):
         self.project_root = Path(__file__).parent.parent.parent
         java_jar_dir = self.project_root / "lib/java/target"
-        jar_files = list(java_jar_dir.glob("open-token-*.jar"))
+    jar_files = list(java_jar_dir.glob("opentoken-*.jar"))
         if not jar_files:
             raise FileNotFoundError(f"No OpenToken JAR found in {java_jar_dir}")
         self.java_jar_path = jar_files[0]


### PR DESCRIPTION
This PR standardizes the Java library coordinates and documentation. 

1. Renamed Maven artifactId from open-token → **opentoken**.
2. Updated groupId to **com.truveta**, removing the redundant .opentoken segment.
3. Updated documentation and examples to use a wildcard JAR pattern (opentoken-*.jar) to reduce churn across releases.